### PR TITLE
Add babel-cli dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "update": "git pull && npm install"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "codemirror": "^5.28.0",
     "diff": "^3.3.0",


### PR DESCRIPTION
The ```npm run-script run``` command calls ```babel```, which is provided by the package ```babel-cli```.